### PR TITLE
Update NuGet icon link in README_Feature.md

### DIFF
--- a/README_Feature.md
+++ b/README_Feature.md
@@ -2,7 +2,12 @@
 Everything in here is of course optional. If you want to add/remove something, absolutely do so as you see fit.
 This example README has some dummy APIs you'll need to replace and only acts as a placeholder for some inspiration that you can fill in with your own functionalities.
 -->
-![](nuget.png)
+<!-- 
+NuGet.org allows only images from certain domains. Complete list is here: https://learn.microsoft.com/en-us/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges.
+In case of GitHub there is required a raw URI of icon file - direct link to github.com domain is not permitted.
+(Tip: to obtain raw URI, open the .png image file on GitHub page, click right mouse button on image and then select 'Open image in new tab')
+-->
+![nuget.png](https://raw.githubusercontent.com/jfversluis/Plugin.Maui.Feature/main/nuget.png)
 # Plugin.Maui.Feature
 
 `Plugin.Maui.Feature` provides the ability to do this amazing thing in your .NET MAUI application.


### PR DESCRIPTION
Adding direct link to the nuget.png file results with this warning on NuGet.org package README page:
![image](https://github.com/user-attachments/assets/3f4a9e5b-6b46-444f-ad03-ca74b8e7e7d6)

NuGet.org allows only images from certain domains. Complete list is here: https://learn.microsoft.com/en-us/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges.

In case of GitHub there is required a raw URI of icon file - direct link to github.com domain is not permitted.